### PR TITLE
Update README to include step to fix login loop after first login via OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,25 @@ Then, publish the migration:
 php artisan vendor:publish --provider="DirectoryTree\Bartender\BartenderServiceProvider"
 ```
 
+Update your User model to allow filling of the `provider_id` and `provider_name` fields:
+
+```php
+// app/Models/User.php
+
+/**
+ * The attributes that are mass assignable.
+ *
+ * @var array<int, string>
+ */
+protected $fillable = [
+    'name',
+    'email',
+    'password',
+    'provider_id',
+    'provider_name'
+];
+```
+
 Finally, run the migration:
 
 ```bash


### PR DESCRIPTION
# Instructions to allow filling provider fields on User model

After installing and setting up Bartender I was able to login to my app via Google OAuth. I then logged out and tried to login again and it would send me back to the Login page.

As it turned out, when the user was created for the first time, Bartender was not able to set the 'provider_id' and 'provider_name' fields on the new user and so the next time it attempted to login it assumed the user was created without an OAuth provider.

This PR updates the README to provide instructions for future Bartender users to not run into the same issue I had :sweat_smile: 