### PR TITLE
Bug 10 - Argument #2 ($user) must be of type Laravel\Socialite\Two\User

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ namespace App\Socialite;
 use App\Models\User;
 use Illuminate\Contracts\Auth\Authenticatable;
 use DirectoryTree\Bartender\ProviderRepository;
-use Laravel\Socialite\Two\User as SocialiteUser;
+use Laravel\Socialite\Contracts\User as SocialiteUser;
 
 class UserProviderRepository implements ProviderRepository
 {

--- a/src/ProviderRedirector.php
+++ b/src/ProviderRedirector.php
@@ -5,7 +5,7 @@ namespace DirectoryTree\Bartender;
 use Exception;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\RedirectResponse;
-use Laravel\Socialite\Two\User as SocialiteUser;
+use Laravel\Socialite\Contracts\User as SocialiteUser;
 
 interface ProviderRedirector
 {

--- a/src/ProviderRepository.php
+++ b/src/ProviderRepository.php
@@ -3,7 +3,7 @@
 namespace DirectoryTree\Bartender;
 
 use Illuminate\Contracts\Auth\Authenticatable;
-use Laravel\Socialite\Two\User as SocialiteUser;
+use Laravel\Socialite\Contracts\User as SocialiteUser;
 
 interface ProviderRepository
 {

--- a/src/UserProviderHandler.php
+++ b/src/UserProviderHandler.php
@@ -5,7 +5,7 @@ namespace DirectoryTree\Bartender;
 use Exception;
 use Illuminate\Http\RedirectResponse;
 use Laravel\Socialite\Contracts\Provider;
-use Laravel\Socialite\Two\User as SocialiteUser;
+use Laravel\Socialite\Contracts\User as SocialiteUser;
 
 class UserProviderHandler implements ProviderHandler
 {

--- a/src/UserProviderRedirector.php
+++ b/src/UserProviderRedirector.php
@@ -8,7 +8,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Redirector;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
-use Laravel\Socialite\Two\User as SocialiteUser;
+use Laravel\Socialite\Contracts\User as SocialiteUser;
 
 class UserProviderRedirector implements ProviderRedirector
 {

--- a/src/UserProviderRepository.php
+++ b/src/UserProviderRepository.php
@@ -6,10 +6,9 @@ use DirectoryTree\Bartender\Facades\Bartender;
 use Illuminate\Auth\MustVerifyEmail;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
-use Laravel\Socialite\Two\User as SocialiteUser;
+use Laravel\Socialite\Contracts\User as SocialiteUser;
 
 class UserProviderRepository implements ProviderRepository
 {

--- a/tests/UserProviderHandlerTest.php
+++ b/tests/UserProviderHandlerTest.php
@@ -3,7 +3,6 @@
 use DirectoryTree\Bartender\ProviderRepository;
 use DirectoryTree\Bartender\ProviderRedirector;
 use DirectoryTree\Bartender\Tests\User;
-use Illuminate\Support\Facades\Auth;
 use Laravel\Socialite\Contracts\Provider;
 use Laravel\Socialite\Two\User as SocialiteUser;
 use DirectoryTree\Bartender\UserProviderHandler;


### PR DESCRIPTION
Closes #10 

This PR fixes the Bartender contracts to use the proper base Socialite `User` interface instead of the `Two\User` class:

```diff
- use Laravel\Socialite\Two\User as SocialiteUser;
+ use Laravel\Socialite\Contracts\User as SocialiteUser;
```

This would normally be a breaking change, but I believe this is more so a bug and can thus be placed in a minor update.